### PR TITLE
Fix uninitialized value error ..

### DIFF
--- a/plugins/check-snmp-mem
+++ b/plugins/check-snmp-mem
@@ -223,10 +223,12 @@ sub get_base_mem_usage {
     $stat->{memusedper} = sprintf("%.2f", 100 * $stat->{memused} / $stat->{memtotal});
 
     # swap
-    $stat->{swaptotal} = $mem_base->{$mem->{virt_total}} * $mem_base->{$mem->{virt_unit}};
-    $stat->{swapused} = $mem_base->{$mem->{virt_used}} * $mem_base->{$mem->{virt_unit}};
-    $stat->{swapfree} = $stat->{swaptotal} - $stat->{swapused};
-
+    if ($mem->{virt_unit}) {
+        $stat->{swaptotal} = $mem_base->{$mem->{virt_total}} * $mem_base->{$mem->{virt_unit}};
+        $stat->{swapused} = $mem_base->{$mem->{virt_used}} * $mem_base->{$mem->{virt_unit}};
+        $stat->{swapfree} = $stat->{swaptotal} - $stat->{swapused};
+    }
+    
     if ($stat->{swaptotal}) {
         $stat->{swapusedper} = sprintf("%.2f", 100 * $stat->{swapused} / $stat->{swaptotal});
     } else {


### PR DESCRIPTION
.. in case a system has no swap:

Use of uninitialized value in hash element at ./check-snmp-mem line 226.
Use of uninitialized value in hash element at ./check-snmp-mem line 226.
Use of uninitialized value in multiplication (*) at ./check-snmp-mem line 226.
Use of uninitialized value in multiplication (*) at ./check-snmp-mem line 226.
Use of uninitialized value in hash element at ./check-snmp-mem line 227.
Use of uninitialized value in hash element at ./check-snmp-mem line 227.
Use of uninitialized value in multiplication (*) at ./check-snmp-mem line 227.
Use of uninitialized value in multiplication (*) at ./check-snmp-mem line 227.

{"message":"memusedper=61.89%, swapusedper=0.00%","status":"OK","stats":{"swaptotal":0,"swapused":0,"memusedper":"61.89","memfree":52365250560,"memused":85038661632,"memtotal":137403912192,"swapfree":0,"buffers":0,"swapusedper":"0.00","cached":0}}